### PR TITLE
use golang/crypto's xc20p1305 library for Go url

### DIFF
--- a/draft-xchacha-rfc-00.txt
+++ b/draft-xchacha-rfc-00.txt
@@ -101,8 +101,8 @@ Table of Contents
        normal.  The definition for XChaCha20 is given in Section 2.3.
 
    XChaCha20-Poly1305 implementations already exist in WireGuard [1],
-   libsodium [2], Monocypher [3], xsecretbox [4], and a standalone Go
-   [5] library.
+   libsodium [2], Monocypher [3], xsecretbox [4], and in Go's crypto/
+   chacha20poly1305 [5] library.
 
 
 
@@ -282,7 +282,7 @@ Arciszewski               Expires March 1, 2019                 [Page 5]
 Internet-Draft                                               August 2018
 
 
-   [5] https://github.com/aead/chacha20
+   [5] https://godoc.org/golang.org/x/crypto/chacha20poly1305#NewX
 
    [6] https://cr.yp.to/snuffle/xsalsa-20110204.pdf
 

--- a/xchacha.md
+++ b/xchacha.md
@@ -56,7 +56,7 @@ XChaCha20-Poly1305 implementations already exist in
 [libsodium](https://download.libsodium.org/doc/secret-key_cryptography/xchacha20-poly1305_construction.html),
 [Monocypher](https://github.com/LoupVaillant/Monocypher),
 [xsecretbox](https://github.com/jedisct1/xsecretbox),
-and a standalone [Go](https://github.com/aead/chacha20) library.
+and in Go's [crypto/chacha20poly1305](https://godoc.org/golang.org/x/crypto/chacha20poly1305#NewX) library.
 
 ## Motivation for XChaCha20-Poly1305
 


### PR DESCRIPTION
The Go team [recently added](https://github.com/golang/crypto/commit/f792edd33d2c59a74c4d81e9b9a536e5301a8b83) an official [XChaCha20-Poly1305](https://godoc.org/golang.org/x/crypto/chacha20poly1305#NewX) implementation in the [golang/crypto](https://github.com/golang/crypto) repository. I suggest we change the previous url to golang/crypto's one.